### PR TITLE
Remove python-opencv from the package dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-opencv-python
 pynetworktables
 pyserial
 numpy


### PR DESCRIPTION
This is useful when python-opencv needs to be installed manually, e.g. when it was installed using a Linux distribution package manager. In this case, we need to be able to use ovl with the AArch64 Alpine Linux py3-opencv package.